### PR TITLE
Ensure install target dir exists

### DIFF
--- a/modules/AddSMTGLibrary.cmake
+++ b/modules/AddSMTGLibrary.cmake
@@ -76,6 +76,7 @@ function (smtg_create_link_to_plugin target)
     else()
         add_custom_command(
             TARGET ${target} POST_BUILD
+	    COMMAND mkdir -p "${TARGET_DESTINATION}"
             COMMAND ln -sfF "${TARGET_SOURCE}" "${TARGET_DESTINATION}"
         )
     endif()


### PR DESCRIPTION
This change adds a `mkdir -p` command before the plugin is
linked into the `${TARGET_DESTINATION}` directory by the
`AddSMTGLibrary.cmake` module, to ensure that the directory
exists. This addresses the following build failure:

Building on Fedora Linux 29, I encountered an error after passing
the TestSuite checks on the first plugin (adelay), when the build
process attempted to link into a nonexistent directory.
```
-------------------------------------------------------------
TestSuite : ADelayTest Factory
-------------------------------------------------------------

[ExampleTest]
[Succeeded]

[Ringbuffer Tests]
[Succeeded]

-------------------------------------------------------------
Result: 42 tests passed, 0 tests failed
-------------------------------------------------------------
ln: target '/home/ferd/.vst3/' is not a directory: No such file or directory
make[2]: *** [public.sdk/samples/vst/adelay/CMakeFiles/adelay.dir/build.make:164: VST3/Debug/adelay.vst3/Contents/x86_64-linux/adelay.so] Error 1
make[2]: *** Deleting file 'VST3/Debug/adelay.vst3/Contents/x86_64-linux/adelay.so'
make[1]: *** [CMakeFiles/Makefile2:664: public.sdk/samples/vst/adelay/CMakeFiles/adelay.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```