### PR TITLE
enable detecting the target platform for MSVC 2019

### DIFF
--- a/modules/SetupVST3LibraryDefaultPath.cmake
+++ b/modules/SetupVST3LibraryDefaultPath.cmake
@@ -3,7 +3,7 @@
 function(smtg_get_default_vst3_path)
     if(SMTG_WIN)
         string(FIND ${CMAKE_GENERATOR} Win64 win64Found)
-        if(${win64Found} EQUAL -1)
+        if((NOT ${CMAKE_GENERATOR_PLATFORM} STREQUAL "x64") AND (${win64Found} EQUAL -1))
             if(EXISTS "$ENV{PROGRAMFILES} (x86)")
                 set(DEFAULT_VST3_FOLDER "$ENV{PROGRAMFILES} (x86)\\Common Files\\VST3" PARENT_SCOPE)
             else()


### PR DESCRIPTION
The target platform for DEFAULT_VST3_FOLDER  is not detected correctly when run cmake with Visual Studio 2019 generator, which does not support old style target specifier suffix like "Visual Studio 15 2017 **Win64**".

Thus check CMAKE_GENERATOR_PLATFORM too.