### PR TITLE
smtg_strip_symbols_with_dbg: use cmake's variables for objcopy and strip

### DIFF
--- a/modules/AddSMTGLibrary.cmake
+++ b/modules/AddSMTGLibrary.cmake
@@ -62,9 +62,9 @@ endfunction()
 function (smtg_strip_symbols_with_dbg target)
     add_custom_command(TARGET ${target} POST_BUILD
         # Create a target.so.dbg file with debug information
-        COMMAND ${CMAKE_COMMAND_OBJECT_COPY} objcopy --only-keep-debug $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.dbg
-        COMMAND ${CMAKE_COMMAND_STRIP} strip --strip-debug --strip-unneeded $<TARGET_FILE:${target}>
-        COMMAND ${CMAKE_COMMAND_OBJECT_COPY} objcopy --add-gnu-debuglink=$<TARGET_FILE:${target}>.dbg $<TARGET_FILE:${target}>
+        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.dbg
+        COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:${target}>
+        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:${target}>.dbg $<TARGET_FILE:${target}>
     )
 endfunction()
 


### PR DESCRIPTION
when cross-compiling, the host's objcopy or strip executables may not be
able to deal with the generated binaries. in this case one has to use the
cmake variables which are provided by the toolchain file