### PR TITLE
fixing regression for non-bundle Windows VST3s

### DIFF
--- a/modules/SMTG_AddSMTGLibrary.cmake
+++ b/modules/SMTG_AddSMTGLibrary.cmake
@@ -419,7 +419,11 @@ function(smtg_target_make_plugin_package target pkg_name extension)
         endif()
     endif(SMTG_MAC)
 
-    smtg_target_create_resources_folder(${target})
+    # create folder for bundle resources, but only if creating a bundle is configured (Windows)
+    if(NOT SMTG_WIN OR SMTG_CREATE_BUNDLE_FOR_WINDOWS)
+       smtg_target_create_resources_folder(${target})
+    endif()
+
 endfunction(smtg_target_make_plugin_package)
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
The previous update on the officital SDK broke the functionality to build VST3s that are not bundles on Windows.

The cmake script always created a folder for the bundle structure despite it should be a DLL later to be linked to.
