### PR TITLE
msvc: fix c++20 builds

### DIFF
--- a/modules/SMTG_PlatformToolset.cmake
+++ b/modules/SMTG_PlatformToolset.cmake
@@ -91,6 +91,7 @@ macro(smtg_setup_platform_toolset)
             add_compile_options(/wd6386)                    # Buffer overrun
             add_compile_options(/wd28125)                   # The function must be called from within a try/except block
             add_compile_options(/wd28251)                   # Inconsistent annotation for function
+            add_compile_options(/Zc:__cplusplus)            # __cplusplus should denote the c++ standard
             #add_definitions("/analyze")                     # Enable Code Analyze
 
             set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /SAFESEH:NO")


### PR DESCRIPTION
SMTG_CPP20 depends on __cplusplus, but cl.exe only defines __cplusplus correctly when building with /Zc:__cplusplus. otherwise it is hardcoded to 199711L